### PR TITLE
MIP Changes 

### DIFF
--- a/src/MIP_Phase1.java
+++ b/src/MIP_Phase1.java
@@ -541,21 +541,21 @@ public class MIP_Phase1
 	public void initSoft1() throws IloException { // ATV spread
 		for (ContractGroup group : this.instance.getContractGroups()) { //For all contract groups
 			if (group.getDutyTypes().contains("ATV")) { //If this group can work ATV duties
-				for (int s = 0; s < group.getTc(); s++) {//For all weeks
+				for (int w = 0; w < group.getTc()/7; w++) {//For all weeks
 					IloLinearNumExpr constraint = this.cplex.linearNumExpr();
 					
 					for(int t = 0; t < 14; t++) {
-						IloNumVar decVarATV = this.decVarOfThisType(this.daysPerGroup.get(group).get((s+t)%group.getTc()), "ATV");
+						IloNumVar decVarATV = this.decVarOfThisType(this.daysPerGroup.get(group).get(((7*w)+t)%group.getTc()), "ATV");
 						constraint.addTerm(decVarATV, 1);
 					}
 
 					//Add a penalty 
 					IloNumVar penalty = this.cplex.intVar(0, Integer.MAX_VALUE);
-					penalty.setName(group.groupNumberToString() + "ATVSpread_S" + s);
+					penalty.setName(group.groupNumberToString() + "ATVSpread_W" + w);
 					this.ATVSpreadPenalty.add(penalty);
 					constraint.addTerm(penalty, -1);
 					
-					this.cplex.addLe(constraint, 1, group.groupNumberToString() + "ATVSpread_S" + s);
+					this.cplex.addLe(constraint, 1, group.groupNumberToString() + "ATVSpread_W" + w);
 				}
 			}
 		}

--- a/src/MIP_Phase1.java
+++ b/src/MIP_Phase1.java
@@ -124,11 +124,12 @@ public class MIP_Phase1
 	//Source: https://www.ibm.com/support/knowledgecenter/SSSA5P_12.7.1/ilog.odms.cplex.help/CPLEX/OverviewAPIs/topics/Soln_pool.html
 	public void populate(int nsol) throws IloException{
 		this.cplex.setParam(IloCplex.IntParam.SolnPoolCapacity, nsol);
-		this.cplex.setParam(IloCplex.IntParam.SolnPoolReplace, 1);
+		//this.cplex.setParam(IloCplex.IntParam.SolnPoolReplace, 1);
 		//this.cplex.setParam(IloCplex.DoubleParam.SolnPoolGap, 0);
 		this.cplex.setParam(IloCplex.DoubleParam.SolnPoolAGap, 0.5);
 		//this.cplex.setParam(IloCplex.IntParam.SolnPoolIntensity, 1);
-		//this.cplex.setParam(IloCplex.IntParam.PopulateLim, 2100000000);
+		//this.cplex.setParam(IloCplex.IntParam.PopulateLim, 1);
+		this.cplex.setParam(IloCplex.DoubleParam.TimeLimit, 60);
 		this.cplex.populate();
 		System.out.println("Solution pool size: " + cplex.getSolnPoolNsolns());
 	}
@@ -980,7 +981,7 @@ public class MIP_Phase1
 					// ATV days
 					String type = this.decVarToCombination.get(decVar).getType();
 					if (type.equals("ATV")) {
-						constraint.addTerm(decVar, group.getAvgHoursPerDay()*60);
+						constraint.addTerm(decVar, (int) group.getAvgHoursPerDay()*60);
 					}
 
 					// Normal duties
@@ -999,7 +1000,7 @@ public class MIP_Phase1
 
 						// Reserve duties
 						if (ch.equals('R')) {
-							constraint.addTerm(decVar, group.getAvgHoursPerDay()*60);
+							constraint.addTerm(decVar, (int) group.getAvgHoursPerDay()*60);
 						}
 					}
 				}

--- a/src/MIP_Phase1.java
+++ b/src/MIP_Phase1.java
@@ -433,7 +433,9 @@ public class MIP_Phase1
 			IloLinearNumExpr constraint = this.cplex.linearNumExpr();
 			for(int w = 0; w < group.getTc()/7; w++) { //Summing all weeks
 				for(IloNumVar decVar : this.daysPerGroup.get(group).get(w*7)) {//All decision variables on sunday
-					constraint.addTerm(decVar, 1);
+					if(!this.decVarToCombination.get(decVar).getType().equals("ATV")) {
+						constraint.addTerm(decVar, 1);
+					}
 				}				
 			}
 			int numberOfSundays = (int) (Math.floor((group.getTc()/7 * 3/4))); //Rounding down 

--- a/src/MIP_Phase1.java
+++ b/src/MIP_Phase1.java
@@ -564,12 +564,12 @@ public class MIP_Phase1
 	public void initSoft2() throws IloException { // Reserve per period of 7 days 
 		for (ContractGroup group : this.instance.getContractGroups()) { //For all contract groups
 
-			for (int s = 0; s < group.getTc(); s++) { //Starting on every day
+			for (int w = 0; w < group.getTc()/7; w++) { //Starting on every day
 				
 				IloLinearNumExpr constraint = this.cplex.linearNumExpr();
 				
 				for(int t = 0; t < 7; t++) {
-					for(IloNumVar decVar : this.daysPerGroup.get(group).get((s+t)%group.getTc())) {
+					for(IloNumVar decVar : this.daysPerGroup.get(group).get(((7*w)+t)%group.getTc())) {
 						String type = this.decVarToCombination.get(decVar).getType();
 						Character ch = type.charAt(0);
 						if(ch.equals('R')) {
@@ -577,14 +577,13 @@ public class MIP_Phase1
 						}
 					}
 				}
-
 				//Add the penalty
 				IloNumVar penalty = this.cplex.intVar(0, Integer.MAX_VALUE);
-				penalty.setName(group.groupNumberToString() + "Reserve_S" + s);
+				penalty.setName(group.groupNumberToString() + "Reserve_W" + w);
 				this.reservePenalty.add(penalty);
 				
 				constraint.addTerm(penalty, -1);
-				this.cplex.addLe(constraint, 2, group.groupNumberToString() + "Reserve_S" + s);
+				this.cplex.addLe(constraint, 2, group.groupNumberToString() + "Reserve_W" + w);
 			}
 		}
 	}
@@ -612,6 +611,7 @@ public class MIP_Phase1
 			}
 		}
 	}
+	
 	
 	public void initSoft4() throws IloException { //Max consecutive similar duties 
 		for(ContractGroup group: this.instance.getContractGroups()) {//For all contract groups
@@ -938,26 +938,26 @@ public class MIP_Phase1
 	
 	public void initSoft13() throws IloException { // Spread the rest
 		for (ContractGroup group : this.instance.getContractGroups()) { // For all contract groups
-			for (int s = 0; s < group.getTc(); s++) {// For all days
+			for (int w = 0; w < group.getTc()/7; w++) {// For all days
 				IloLinearNumExpr constraint = this.cplex.linearNumExpr();
 
 				//The week from that day onwards 
 				for (int t = 0; t < 7; t++) {
 					IloNumVar decVarATV = this
-							.decVarOfThisType(this.daysPerGroup.get(group).get((s + t) % group.getTc()), "ATV");
+							.decVarOfThisType(this.daysPerGroup.get(group).get(((7*w) + t) % group.getTc()), "ATV");
 					if(decVarATV != null) {
 						constraint.addTerm(decVarATV, 1);
 					}
-					constraint.addTerm(this.restDaysPerGroup.get(group)[(s + t) % group.getTc()], 1);
+					constraint.addTerm(this.restDaysPerGroup.get(group)[((7*w) + t) % group.getTc()], 1);
 				}
 
 				// Add a penalty
 				IloNumVar penalty = this.cplex.intVar(0, Integer.MAX_VALUE);
-				penalty.setName(group.groupNumberToString() + "RestSpread_S" + s);
+				penalty.setName(group.groupNumberToString() + "RestSpread_W" + w);
 				this.RestSpread.add(penalty);
 				constraint.addTerm(penalty, -1);
 
-				this.cplex.addLe(constraint, 3, group.groupNumberToString() + "RestSpread_S" + s);
+				this.cplex.addLe(constraint, 3, group.groupNumberToString() + "RestSpread_W" + w);
 			}
 		}
 	}

--- a/src/Main.java
+++ b/src/Main.java
@@ -64,7 +64,7 @@ public class Main
 		instance.setViol(temp.get11Violations(), temp.get32Violations(), temp.getViolations3Days());
 		System.out.println("Instance " + depot + " initialised");
 		
-		int numberOfDrivers = instance.getUB();
+		int numberOfDrivers = instance.getLB()+19;
 		instance.setNrDrivers(numberOfDrivers);
 
 		Phase1_Penalties penalties = new Phase1_Penalties();

--- a/src/Main.java
+++ b/src/Main.java
@@ -22,7 +22,7 @@ public class Main
 {
 	public static void main(String[] args) throws FileNotFoundException, IloException {
 		// ---------------------------- Variable Input ------------------------------------------------------------
-		String depot = "Dirksland"; //adjust to "Dirksland" or "Heinenoord"
+		String depot = "Heinenoord"; //adjust to "Dirksland" or "Heinenoord"
 		int dailyRestMin = 11 * 60; //amount of daily rest in minutes
 		int restDayMin = 36 * 60; //amount of rest days in minutes (at least 32 hours in a row in one week)
 		int restDayMinCG = 32*60;
@@ -64,21 +64,22 @@ public class Main
 		instance.setViol(temp.get11Violations(), temp.get32Violations(), temp.getViolations3Days());
 		System.out.println("Instance " + depot + " initialised");
 		
-		int numberOfDrivers = instance.getLB() +14;
+		int numberOfDrivers = instance.getLB()+23;
 		instance.setNrDrivers(numberOfDrivers);
 
 		Phase1_Penalties penalties = new Phase1_Penalties();
 		Set<Schedule> schedules = new HashSet<>();
 		int iteration = 0;
-		int maxIt = 3;
+		int maxIt = 50;
 		boolean scheduleForEveryGroup = false;
 		MIP_Phase1 mip = new MIP_Phase1(instance, dutyTypes, penalties);
 		mip.solve();
 		if (mip.isFeasible()) {
-			//mip.populate(maxIt);
-			//while (scheduleForEveryGroup == false && iteration < maxIt) {
-				mip.makeSolution(); //When not using populate 
-				//mip.makeSolution(iteration); //When using populate
+			//int nsol = mip.populate(maxIt);
+			int nsol = 1;
+			while (scheduleForEveryGroup == false && iteration < nsol) {
+				//mip.makeSolution(); //When not using populate 
+				mip.makeSolution(iteration); //When using populate
 				instance.setBasicSchedules(mip.getSolution());
 				
 				for(ContractGroup c : instance.getContractGroups()) {
@@ -106,7 +107,7 @@ public class Main
 					}
 				}
 				iteration++;
-			//}
+			}
 			
 			if(iteration == maxIt || schedules.size() == 0) {
 				System.out.println("No feasible schedules found on all " + maxIt + " basic schedules");

--- a/src/Main.java
+++ b/src/Main.java
@@ -22,7 +22,7 @@ public class Main
 {
 	public static void main(String[] args) throws FileNotFoundException, IloException {
 		// ---------------------------- Variable Input ------------------------------------------------------------
-		String depot = "Heinenoord"; //adjust to "Dirksland" or "Heinenoord"
+		String depot = "Dirksland"; //adjust to "Dirksland" or "Heinenoord"
 		int dailyRestMin = 11 * 60; //amount of daily rest in minutes
 		int restDayMin = 36 * 60; //amount of rest days in minutes (at least 32 hours in a row in one week)
 		int restDayMinCG = 32*60;
@@ -64,25 +64,25 @@ public class Main
 		instance.setViol(temp.get11Violations(), temp.get32Violations(), temp.getViolations3Days());
 		System.out.println("Instance " + depot + " initialised");
 		
-		int numberOfDrivers = instance.getLB() +35;
+		int numberOfDrivers = instance.getLB() +14;
 		instance.setNrDrivers(numberOfDrivers);
 
 		Phase1_Penalties penalties = new Phase1_Penalties();
 		Set<Schedule> schedules = new HashSet<>();
-		int iteration = 1;
-		int maxIt = 5;
+		int iteration = 0;
+		int maxIt = 3;
 		boolean scheduleForEveryGroup = false;
 		MIP_Phase1 mip = new MIP_Phase1(instance, dutyTypes, penalties);
 		mip.solve();
 		if (mip.isFeasible()) {
 			//mip.populate(maxIt);
-			//while (scheduleForEveryGroup == false && iteration <= maxIt) {
+			//while (scheduleForEveryGroup == false && iteration < maxIt) {
 				mip.makeSolution(); //When not using populate 
 				//mip.makeSolution(iteration); //When using populate
 				instance.setBasicSchedules(mip.getSolution());
 				
 				for(ContractGroup c : instance.getContractGroups()) {
-				//	new ScheduleVis(instance.getBasicSchedules().get(c), ""+c.getNr());
+					new ScheduleVis(instance.getBasicSchedules().get(c), ""+c.getNr());
 				}
 
 				long phase3Start = System.nanoTime();

--- a/src/Main.java
+++ b/src/Main.java
@@ -22,7 +22,7 @@ public class Main
 {
 	public static void main(String[] args) throws FileNotFoundException, IloException {
 		// ---------------------------- Variable Input ------------------------------------------------------------
-		String depot = "Heinenoord"; //adjust to "Dirksland" or "Heinenoord"
+		String depot = "Dirksland"; //adjust to "Dirksland" or "Heinenoord"
 		int dailyRestMin = 11 * 60; //amount of daily rest in minutes
 		int restDayMin = 36 * 60; //amount of rest days in minutes (at least 32 hours in a row in one week)
 		int restDayMinCG = 32*60;
@@ -64,22 +64,21 @@ public class Main
 		instance.setViol(temp.get11Violations(), temp.get32Violations(), temp.getViolations3Days());
 		System.out.println("Instance " + depot + " initialised");
 		
-		int numberOfDrivers = instance.getLB()+23;
+		int numberOfDrivers = instance.getUB();
 		instance.setNrDrivers(numberOfDrivers);
 
 		Phase1_Penalties penalties = new Phase1_Penalties();
 		Set<Schedule> schedules = new HashSet<>();
 		int iteration = 0;
-		int maxIt = 50;
+		int maxIt = 5;
 		boolean scheduleForEveryGroup = false;
 		MIP_Phase1 mip = new MIP_Phase1(instance, dutyTypes, penalties);
 		mip.solve();
 		if (mip.isFeasible()) {
-			//int nsol = mip.populate(maxIt);
-			int nsol = 1;
+			//int nsol = mip.populate(maxIt); //When using populate
+			int nsol = 1; //When not using populate 
 			while (scheduleForEveryGroup == false && iteration < nsol) {
-				//mip.makeSolution(); //When not using populate 
-				mip.makeSolution(iteration); //When using populate
+				mip.makeSolution(iteration); 
 				instance.setBasicSchedules(mip.getSolution());
 				
 				for(ContractGroup c : instance.getContractGroups()) {

--- a/src/Phase1_Penalties.java
+++ b/src/Phase1_Penalties.java
@@ -13,6 +13,7 @@ public class Phase1_Penalties {
 	private final int ATVonWeekendParam;
 	private final int lonelyDutyParam;
 	private final int splitDutiesParam;
+	private final int restSpreadParam;
 	
 	public Phase1_Penalties() {
 		this.ATVSpreadPenaltyParam = 1;
@@ -28,6 +29,7 @@ public class Phase1_Penalties {
 		this.ATVonWeekendParam = 1;
 		this.lonelyDutyParam = 1;
 		this.splitDutiesParam = 1000;
+		this.restSpreadParam = 1;
 	}
 
 	public int getATVSpreadPenaltyParam() {
@@ -80,5 +82,9 @@ public class Phase1_Penalties {
 	
 	public int getSplitDutiesParam() {
 		return splitDutiesParam;
+	}
+	
+	public int getRestSpreadParam() {
+		return restSpreadParam;
 	}
 }

--- a/src/Phase1_Penalties.java
+++ b/src/Phase1_Penalties.java
@@ -9,6 +9,8 @@ public class Phase1_Penalties {
 	private final int earlyToLateParam;
 	private final int partTimeParam;
 	private final int fivePerWeekParam;
+	private final int ATVonWeekendParam;
+	private final int lonelyDutyParam;
 	
 	public Phase1_Penalties() {
 		this.ATVSpreadPenaltyParam = 1;
@@ -20,6 +22,8 @@ public class Phase1_Penalties {
 		this.earlyToLateParam = 1;
 		this.partTimeParam = 1;
 		this.fivePerWeekParam = 1;
+		this.ATVonWeekendParam = 1;
+		this.lonelyDutyParam = 1;
 	}
 
 	public int getATVSpreadPenaltyParam() {
@@ -56,5 +60,13 @@ public class Phase1_Penalties {
 	
 	public int getFivePerWeekParam() {
 		return fivePerWeekParam;
+	}
+	
+	public int getATVonWeekendParam() {
+		return ATVonWeekendParam;
+	}
+	
+	public int getLonelyDutyParam() {
+		return lonelyDutyParam;
 	}
 }

--- a/src/Phase1_Penalties.java
+++ b/src/Phase1_Penalties.java
@@ -9,12 +9,14 @@ public class Phase1_Penalties {
 	private final int earlyToLateParam;
 	private final int partTimeParam;
 	private final int fivePerWeekParam;
+	private final int fivePerWeek40Param;
 	private final int ATVonWeekendParam;
 	private final int lonelyDutyParam;
+	private final int splitDutiesParam;
 	
 	public Phase1_Penalties() {
 		this.ATVSpreadPenaltyParam = 1;
-		this.reservePenaltyParam = 1;
+		this.reservePenaltyParam = 1000;
 		this.tooManyConsecutiveDutiesParam = 1;
 		this.consecutiveMaxPenaltyParam = 1;
 		this.consecutiveMinPenaltyParam = 1;
@@ -22,8 +24,10 @@ public class Phase1_Penalties {
 		this.earlyToLateParam = 1;
 		this.partTimeParam = 1;
 		this.fivePerWeekParam = 1;
+		this.fivePerWeek40Param = 1;
 		this.ATVonWeekendParam = 1;
 		this.lonelyDutyParam = 1;
+		this.splitDutiesParam = 1000;
 	}
 
 	public int getATVSpreadPenaltyParam() {
@@ -62,11 +66,19 @@ public class Phase1_Penalties {
 		return fivePerWeekParam;
 	}
 	
+	public int getFivePerWeek40Param() {
+		return fivePerWeek40Param;
+	}
+	
 	public int getATVonWeekendParam() {
 		return ATVonWeekendParam;
 	}
 	
 	public int getLonelyDutyParam() {
 		return lonelyDutyParam;
+	}
+	
+	public int getSplitDutiesParam() {
+		return splitDutiesParam;
 	}
 }

--- a/src/Phase4_AddMissing.java
+++ b/src/Phase4_AddMissing.java
@@ -130,7 +130,9 @@ public class Phase4_AddMissing {
 			}
 
 			int tries = 0;
-			while (missingDuties(schedulesCopy) > 0 && tries < 5000) {
+			int totalMissing = missingDuties(schedulesCopy);
+			int currentMissing = totalMissing;
+			while (currentMissing > 0 && tries < (Math.pow(totalMissing, 2) +1000)) {
 				int i = (int) (Math.random() * 7); // Pick a random weekday
 				if (originalMissing.get(i).size() > 0) {
 					int insertNr = (int) (Math.random() * originalMissing.get(i).size());
@@ -162,9 +164,9 @@ public class Phase4_AddMissing {
 															toInsert.getStartTime(), toInsert.getEndTime())) {
 														scheduleArray[t * 7 + i] = toInsert.getNr();
 														if (scheduleIsFeasible(scheduleArray, schedulesCopy.get(random).getC())) {
-															// System.out.println("Swapped:" + " " + (i) + " " + random+ " "+ toInsert.getNr() + " " + toDelete.getNr());
 															duplicatesTaken.get(i).add(toDelete);
 															insertedDuties.get(i).add(toInsert);
+															currentMissing = missingDuties(schedulesCopy);
 														} else {
 															scheduleArray[t * 7 + i] = toDelete.getNr();
 														}
@@ -174,16 +176,15 @@ public class Phase4_AddMissing {
 										}
 									}
 								}
+								tries++;
 							}
-							tries++;
 						}
 					}
 				}
-
 			}
 			//System.out.println(missingDuties(schedulesCopy));
-			if(missingDuties(schedulesCopy) < minimumMissed) {
-				minimumMissed = missingDuties(schedulesCopy);
+			if(currentMissing < minimumMissed) {
+				minimumMissed = currentMissing;
 				bestSchedules.clear();
 				bestSchedules.addAll(schedulesCopy);
 			}

--- a/src/Phase4_AddMissing.java
+++ b/src/Phase4_AddMissing.java
@@ -347,7 +347,7 @@ public class Phase4_AddMissing {
 								} else {
 									int j = 1;
 									while (schedule[(s+i+j)%schedule.length] == 1 || schedule[(s+i+j)%schedule.length] == 2) {
-										if (i+j == 13) {
+										if (i+j == 14) {
 											consec += start;
 											break;
 										}

--- a/src/Phase4_AddMissing.java
+++ b/src/Phase4_AddMissing.java
@@ -345,8 +345,15 @@ public class Phase4_AddMissing {
 									consec += instance.getFromDutyNrToDuty()
 											.get(schedule[(s + i + 1) % schedule.length]).getStartTime();
 								} else {
-									consec += instance.getFromRDutyNrToRDuty()
-											.get(schedule[(s + i + 1) % schedule.length]).getStartTime();
+									int j = 1;
+									while (schedule[(s+i+j)%schedule.length] == 1 || schedule[(s+i+j)%schedule.length] == 2) {
+										if (i+j == 13) {
+											consec += start;
+											break;
+										}
+										consec += 24 * 60;
+										j++;
+									}
 								}
 							}
 

--- a/src/Phase4_AddMissing.java
+++ b/src/Phase4_AddMissing.java
@@ -130,7 +130,7 @@ public class Phase4_AddMissing {
 			}
 
 			int tries = 0;
-			while (missingDuties(schedulesCopy) > 0 && tries < 2000) {
+			while (missingDuties(schedulesCopy) > 0 && tries < 5000) {
 				int i = (int) (Math.random() * 7); // Pick a random weekday
 				if (originalMissing.get(i).size() > 0) {
 					int insertNr = (int) (Math.random() * originalMissing.get(i).size());
@@ -139,8 +139,9 @@ public class Phase4_AddMissing {
 						if (duplicatesCopy.get(i).size() > 0) {
 							int deleteNr = (int) (Math.random() * duplicatesCopy.get(i).size());
 							Duty toDelete = duplicatesCopy.get(i).get(deleteNr); // Pick a random duplicate to delete
-							if (toInsert.getType().equals(toDelete.getType())
-									&& !duplicatesTaken.get(i).contains(toDelete)) {
+							if (!duplicatesTaken.get(i).contains(toDelete)) {
+									
+									//toInsert.getType().equals(toDelete.getType())&& !duplicatesTaken.get(i).contains(toDelete)) {
 								List<Schedule> schedulesChecked = new ArrayList<>();
 								while (schedulesChecked.size() != schedulesCopy.size()) {
 									int random = (int) (Math.random() * schedulesCopy.size());
@@ -205,7 +206,7 @@ public class Phase4_AddMissing {
 			return false;
 		}
 		if(!overTimeFeasible(schedule,c)) {
-			//System.out.println("Overtime failed");
+		//	System.out.println("Overtime failed");
 			return false;
 		}
 		return true;
@@ -229,52 +230,40 @@ public class Phase4_AddMissing {
 				for (int i = 1; i <= 6; i++) {// For every rolling window of 7 days from this day on
 					if (!rangeFeasible) {
 						// If this day is a rest/ATV day
-						if (schedule[(s + i) % schedule.length] == 1 || schedule[(s + i) % schedule.length] == 2) {
-							int consecRest = 24 * 60;
-
-							// The day before
-							if (instance.getFromDutyNrToDuty()
-									.containsKey(schedule[(s + i - 1) % schedule.length])) {
-								consecRest += 24 * 60 - instance.getFromDutyNrToDuty()
-										.get(schedule[(s + i - 1) % schedule.length]).getEndTime();
-							} else {
-								consecRest += 24 * 60 - instance.getFromRDutyNrToRDuty()
-										.get(schedule[(s + i - 1) % schedule.length]).getEndTime();
+						if (schedule[(s+i)%schedule.length] == 1 || schedule[(s+i)%schedule.length] == 2) {
+							int consec = 24 * 60;
+							
+							//Check the day before 
+							if (instance.getFromDutyNrToDuty().containsKey(schedule[(s+i-1)%schedule.length])) {//Normal duty
+								consec += 24 * 60 - instance.getFromDutyNrToDuty().get(schedule[(s+i-1)%schedule.length]).getEndTime();
+							} else {//Reserve duty
+								consec += 24 * 60 - instance.getFromRDutyNrToRDuty().get(schedule[(s+i-1)%schedule.length]).getEndTime();
 							}
-
-							// If the rest day we're on is the final day of the row, we need to jump one
-							// further
+							
+							//The day after
+							
+							//If it's the last day 
 							if (i == 6) {
-								// We count up to max the start time of the duty
-								if (schedule[(s + 7) % schedule.length] == 1
-										|| schedule[(s + 7) % schedule.length] == 2) {
-									consecRest += start;
-								} else if (instance.getFromDutyNrToDuty()
-										.containsKey(schedule[(s + 7) % schedule.length])) {
-									consecRest += Math.min(start, instance.getFromDutyNrToDuty()
-											.get(schedule[(s + 7) % schedule.length]).getStartTime());
+								//We only count up until the start of the previous duty, or the new duty if it starts earlier 
+								if (schedule[(s+7)%schedule.length] == 1 || schedule[(s+7)%schedule.length] == 2) {
+									consec += start;
+								} else if (instance.getFromDutyNrToDuty().containsKey(schedule[(s+7)%schedule.length])) {
+									consec += Math.min(start, instance.getFromDutyNrToDuty().get(schedule[(s+7)%schedule.length]).getStartTime());
 								} else {
-									consecRest += Math.min(start, instance.getFromRDutyNrToRDuty()
-											.get(schedule[(s + 7) % schedule.length]).getStartTime());
+									consec += Math.min(start, instance.getFromRDutyNrToRDuty().get(schedule[(s+7)%schedule.length]).getStartTime());
 								}
-							}
-							// The day after
+							} 
+							//If it's any other day 
 							else {
-								if (schedule[(s + i + 1) % schedule.length] == 1
-										|| schedule[(s + i + 1) % schedule.length] == 2) {// ATV/rest day
-									consecRest += 24 * 60;
-									// Normal duty
-								} else if (instance.getFromDutyNrToDuty()
-										.containsKey(schedule[(s + i + 1) % schedule.length])) {
-									consecRest += instance.getFromDutyNrToDuty()
-											.get(schedule[(s + i + 1) % schedule.length]).getStartTime();
-									// Reserve duty
+								if (schedule[(s+i+1)%schedule.length] == 1 || schedule[(s+i+1)%schedule.length] == 2) {
+									consec += 24 * 60;
+								} else if (instance.getFromDutyNrToDuty().containsKey(schedule[(s+i+1)%schedule.length])) {
+									consec += instance.getFromDutyNrToDuty().get(schedule[(s+i+1)%schedule.length]).getStartTime();
 								} else {
-									consecRest += instance.getFromRDutyNrToRDuty()
-											.get(schedule[(s + i + 1) % schedule.length]).getStartTime();
+									consec += instance.getFromRDutyNrToRDuty().get(schedule[(s+i+1)%schedule.length]).getStartTime();
 								}
 							}
-							if (consecRest >= 32 * 60) {
+							if (consec >= 32 * 60) {
 								rangeFeasible = true;
 							}
 						}
@@ -337,13 +326,10 @@ public class Phase4_AddMissing {
 							}
 							// Day after, not the end of the period
 							else {
-								if (schedule[(s + i + 1) % schedule.length] == 1
-										|| schedule[(s + i + 1) % schedule.length] == 2) {
-									consec += 24 * 60;
-								} else if (instance.getFromDutyNrToDuty()
-										.containsKey(schedule[(s + i + 1) % schedule.length])) {
-									consec += instance.getFromDutyNrToDuty()
-											.get(schedule[(s + i + 1) % schedule.length]).getStartTime();
+								if (instance.getFromDutyNrToDuty().containsKey(schedule[(s+i+1)%schedule.length])) {
+									consec += instance.getFromDutyNrToDuty().get(schedule[(s+i+1)%schedule.length]).getStartTime();
+								} else if (instance.getFromRDutyNrToRDuty().containsKey(schedule[(s+i+1)%schedule.length])) {
+									consec += instance.getFromRDutyNrToRDuty().get(schedule[(s+i+1)%schedule.length]).getStartTime();
 								} else {
 									int j = 1;
 									while (schedule[(s+i+j)%schedule.length] == 1 || schedule[(s+i+j)%schedule.length] == 2) {

--- a/src/Phase4_ILP.java
+++ b/src/Phase4_ILP.java
@@ -159,7 +159,7 @@ public class Phase4_ILP {
 			objective.addTerm(schedule.getOvertime(), var);
 		}
 		for(IloNumVar var : this.dutyIncludedPenalty) {
-			//objective.addTerm(var, 1);
+			objective.addTerm(var, 1);
 		}
 		this.cplex.addMinimize(objective);
 	}

--- a/src/PricingProblem_Phase3.java
+++ b/src/PricingProblem_Phase3.java
@@ -44,7 +44,7 @@ public class PricingProblem_Phase3
 		this.consecFreeWeekly = consecWeek;
 		this.freeTwoWeeks = twoWeek;
 		initGraphs();
-		this.random = new Random(1000);
+		this.random = new Random(1000); //set a random seed 
 	}
 	
 	/**
@@ -55,8 +55,7 @@ public class PricingProblem_Phase3
 		Map<ContractGroup, Set<Schedule>> negRedCostsSchedules = new HashMap<ContractGroup, Set<Schedule>>();
 		redCostsSP = new HashMap<ContractGroup, List<Double>>();
 		
-		
-		
+		//Calculate the reduced costs of the shortest paths from every node to the end 
 		for (ContractGroup c : instance.getContractGroups()) {
 			Map<Node, Path> distances = this.shortestPathBackward(graphs.get(c), graphs.get(c).getNumberOfNodes()-1, 0, true);
 			List<Double> redCosts = new ArrayList<>();
@@ -67,6 +66,7 @@ public class PricingProblem_Phase3
 		}
 		
 		for (ContractGroup c : instance.getContractGroups()) {			
+			//Initialisation
 			List<Set<Integer>> initDuties = new ArrayList<>();
 			this.startTime = System.nanoTime();
 			
@@ -74,18 +74,60 @@ public class PricingProblem_Phase3
 			for (int i = 0; i < 7; i++) {
 				initDuties.add(new HashSet<>());
 			}
+			
 			Pulse initPulse = new Pulse(0, 0, new int[instance.getBasicSchedules().get(c).length], initDuties, null);
+			
+			Node cur = graphs.get(c).getNodes().get(0);
+			
+			//Initialise pulse again and again until we have found a day that isn't a rest or an ATV duty 
+			while (graphs.get(c).getOutArcs(cur).size() == 1) {
+				DirectedGraphArc<Node, ArcData> curArc = graphs.get(c).getOutArcs(cur).get(0);
+				List<Set<Integer>> newDuties = new ArrayList<>();
+				
+				//Copy the array and add the next duty 
+				int[] schedule = this.copyIntArray(initPulse.getSchedule());
+				schedule[curArc.getTo().getDayNr()] = curArc.getTo().getDutyNr();
+				
+				//Copy the set and add the next duty 
+				for (int i = 0; i < 7; i++) {
+					newDuties.add(this.copySet(initPulse.getDuties().get(i)));
+				}
+				if (instance.getFromDutyNrToDuty().containsKey(curArc.getTo().getDutyNr())) {
+					newDuties.get(curArc.getTo().getDayNr()%7).add(curArc.getTo().getDutyNr());
+				}
+				
+				initPulse = new Pulse(initPulse.getRedCosts() + curArc.getData().getDualCosts(), initPulse.getTotMinWorked() + curArc.getData().getPaidMin(), 
+						schedule, newDuties, initPulse);
+				cur = curArc.getTo();
+			}
+			
 			
 			Set<Schedule> toAdd = new HashSet<>();
 			
+			//Pick a random arc to extend the pulse from 
+			Set<DirectedGraphArc<Node, ArcData>> evaluated = new HashSet<>();
+			int nArcs = graphs.get(c).getOutArcs(cur).size();
+			while (evaluated.size() < nArcs) {
+				DirectedGraphArc<Node, ArcData> outArc = graphs.get(c).getOutArcs(cur).get(random.nextInt(nArcs));
+					if (!evaluated.contains(outArc)) {
+						pulse(graphs.get(c), c, outArc, initPulse);
+						for (Schedule sched : finalSchedules) {
+							toAdd.add(sched);
+						}
+						evaluated.add(outArc);
+						finalSchedules = new HashSet<>();
+					}
+			}
+			
+			/*
 			// Execute the recursive pulse algorithm
-			for (DirectedGraphArc<Node, ArcData> outArc : graphs.get(c).getOutArcs(graphs.get(c).getNodes().get(0))) {
+			for (DirectedGraphArc<Node, ArcData> outArc : graphs.get(c).getOutArcs(cur)) {
 				pulse(graphs.get(c), c, outArc, initPulse);
 				for (Schedule sched : finalSchedules) {
 					toAdd.add(sched);
 				}
 				finalSchedules = new HashSet<>();
-			}
+			}*/
 			
 
 //			Node cur = graphs.get(c).getNodes().get(0);
@@ -120,24 +162,31 @@ public class PricingProblem_Phase3
 	 * @param curPulse				the current pulse
 	 */
 	public void pulse(DirectedGraph<Node, ArcData> graph, ContractGroup c, DirectedGraphArc<Node, ArcData> curArc, Pulse curPulse) {
+		//If we are at the final node
 		if (curArc.getTo().getDayNr() == curPulse.getSchedule().length) {
 			int totOvertime = this.isFeasibleSchedule(curPulse.getSchedule(), c);
+			//This check isn't met if the schedule isn't feasible 
 			if (totOvertime != Integer.MAX_VALUE) {
 				this.finalSchedules.add(new Schedule(c, totOvertime, curPulse.getSchedule()));
 			}
-		} else if (finalSchedules.size() != maxSchedules && (System.nanoTime() - startTime)/1000000000.0 < 100) {
+		} else if (finalSchedules.size() != maxSchedules && (System.nanoTime() - startTime)/1000000000.0 < 10) {
 			// Check whether the new schedule would be feasible in terms of 7x24 and 14x24 hours
 			int[] schedule = this.copyIntArray(curPulse.getSchedule());
 			schedule[curArc.getTo().getDayNr()] = curArc.getTo().getDutyNr();
 			int maxMin = (int) (schedule.length/7 * c.getAvgDaysPerWeek() * c.getAvgHoursPerDay() * 60);
 			if (curArc.getTo().getDayNr() < 7 || this.isFeasible7(schedule, curArc.getTo().getDayNr() - 7)) {
 				if (curArc.getTo().getDayNr() < 14 || this.isFeasible14(schedule, curArc.getTo().getDayNr() - 14)) {
+					
 					// Check whether the overtime will not exceed using basic SP
 					if (curPulse.getTotMinWorked() + curArc.getData().getPaidMin() + this.overtimeSP.get(c).get(graph.getNodes().indexOf(curArc.getTo())) <= maxMin) {
-						// Check whether the overtime will not exceed using the advanced SP
+						
+						// Check whether the reduced cost will be negative using the basic SP 
 						if (curPulse.getRedCosts() + curArc.getData().getDualCosts() + this.redCostsSP.get(c).get(graph.getNodes().indexOf(curArc.getTo())) < 0) {
+							
+							//Check whether the overtime will not exceed using the advanced SP 
 							Path SP = this.shortestPath(graph, graph.getNodes().indexOf(curArc.getTo()), graph.getNumberOfNodes()-1, false, curPulse.getDuties());
 							if (SP != null && (curPulse.getTotMinWorked() + curArc.getData().getPaidMin() + SP.getCosts()) <= maxMin) {
+								
 								// Check whether the reduced costs will be negative using the advanced SP
 								SP = this.shortestPath(graph, graph.getNodes().indexOf(curArc.getTo()), graph.getNumberOfNodes()-1, true, curPulse.getDuties());
 								if (SP != null && (curPulse.getRedCosts() + curArc.getData().getDualCosts() + SP.getCosts()) < 0) {
@@ -156,6 +205,9 @@ public class PricingProblem_Phase3
 //											this.pulse(graph, c, outArc, newPulse);
 //										}
 //									}
+									
+									
+									//Pick a random arc to extend the pulse from 
 									Set<DirectedGraphArc<Node, ArcData>> evaluated = new HashSet<>();
 									int nArcs = graph.getOutArcs(curArc.getTo()).size();
 									while (evaluated.size() < nArcs) {
@@ -172,18 +224,29 @@ public class PricingProblem_Phase3
 								}
 							}
 							else {
-							//	System.out.println("Specific overtime violated");
+						//		System.out.println(c.getNr() + "  " + curArc.getTo().getDayNr() + " Specific overtime violated");
 							}
 						}
 					}
 					else {
-						//System.out.println("Overtime violated");
+					//	System.out.println(c.getNr() + "  " + curArc.getTo().getDayNr() + " Overtime violated");
 					}
 				}
+				else {
+				//	System.out.println(c.getNr() + "  " + curArc.getTo().getDayNr() + " Feasible 14");
+					for(int i = 14; i > 0; i--) {
+				//		System.out.print(curPulse.getSchedule()[curArc.getTo().getDayNr()-i] + " ");
+					}
+				//	System.out.println(instance.getBasicSchedules().get(c)[curArc.getTo().getDayNr()]);
+				}
+			}
+			else {
+			//	System.out.println(c.getNr() + "  " + curArc.getTo().getDayNr() + "Feasible 7");
 			}
 		}
 	}
 	
+	//NO LONGER USED 
 	public Map<ContractGroup, Set<Schedule>> executeLabelling() {
 		Map<ContractGroup, Set<Schedule>> negRedCostsSchedules = new HashMap<ContractGroup, Set<Schedule>>();
 		
@@ -246,6 +309,7 @@ public class PricingProblem_Phase3
 		return negRedCostsSchedules;
 	}
 	
+	//NO LONGER USED
 	public Label getLabel(Label prevLabel, DirectedGraphArc<Node, ArcData> curArc, ContractGroup c) {
 		if (!prevLabel.getDuties().get(curArc.getTo().getDayNr()%7).contains(curArc.getTo().getDutyNr())) {
 			int[] schedule = this.copyIntArray(prevLabel.getSchedule());
@@ -318,6 +382,7 @@ public class PricingProblem_Phase3
 	 * @return						the total number of hours overtime that have to be paid
 	 */
 	public int isFeasibleSchedule(int[] schedule, ContractGroup c) {
+		//Check if the schedule is feasible w.r.t. the 7 and 14 day constraints 
 		for (int t = schedule.length - 6; t < schedule.length; t++) {
 			if (!this.isFeasible7(schedule, t)) {
 				return Integer.MAX_VALUE;
@@ -326,10 +391,12 @@ public class PricingProblem_Phase3
 			}
 		}
 		
+		//Count the hours per week 
 		int[] weeklyHours = new int[instance.getBasicSchedules().get(c).length / 7];
 		for (int i = 0; i < weeklyHours.length; i++) {
 			int totMin = 0;
 			for (int j = 0; j < 7; j++) {
+				//Reserve duty or ATV day 
 				if (schedule[i * 7 + j] == 1 || instance.getFromRDutyNrToRDuty().containsKey(schedule[i * 7 + j])) {
 					totMin += c.getAvgHoursPerDay() * 60;
 				} else if (instance.getFromDutyNrToDuty().containsKey(schedule[i * 7 + j])) {
@@ -339,11 +406,13 @@ public class PricingProblem_Phase3
 			weeklyHours[i] = totMin;
 		}
 		
+		//Counter the total overtime
 		int totMinWorked = 0;		
 		int totOvertime = 0;
 		for (int i = 0; i < weeklyHours.length; i++) {
 			totMinWorked += weeklyHours[i];
 			if (totMinWorked > weeklyHours.length * c.getAvgDaysPerWeek() * c.getAvgHoursPerDay() * 60) {
+				//Abort early 
 				return Integer.MAX_VALUE;
 			}
 			int totMin = 0;
@@ -373,17 +442,24 @@ public class PricingProblem_Phase3
 				start = instance.getFromRDutyNrToRDuty().get(schedule[t]).getStartTime();
 			}
 			
+			//For all days from this day on
 			for (int i = 1; i < 7; i++) {
+				//Only check if this day is an ATV or Rest day
 				if (schedule[(t+i)%schedule.length] == 1 || schedule[(t+i)%schedule.length] == 2) {
 					int consec = 24 * 60;
 					
-					if (instance.getFromDutyNrToDuty().containsKey(schedule[(t+i-1)%schedule.length])) {
+					//Check the day before 
+					if (instance.getFromDutyNrToDuty().containsKey(schedule[(t+i-1)%schedule.length])) {//Normal duty
 						consec += 24 * 60 - instance.getFromDutyNrToDuty().get(schedule[(t+i-1)%schedule.length]).getEndTime();
-					} else {
+					} else {//Reserve duty
 						consec += 24 * 60 - instance.getFromRDutyNrToRDuty().get(schedule[(t+i-1)%schedule.length]).getEndTime();
 					}
 					
+					//The day after
+					
+					//If it's the last day 
 					if (i == 6) {
+						//We only count up until the start of the previous duty, or the new duty if it starts earlier 
 						if (schedule[(t+7)%schedule.length] == 1 || schedule[(t+7)%schedule.length] == 2) {
 							consec += start;
 						} else if (instance.getFromDutyNrToDuty().containsKey(schedule[(t+7)%schedule.length])) {
@@ -391,7 +467,9 @@ public class PricingProblem_Phase3
 						} else {
 							consec += Math.min(start, instance.getFromRDutyNrToRDuty().get(schedule[(t+7)%schedule.length]).getStartTime());
 						}
-					} else {
+					} 
+					//If it's any other day 
+					else {
 						if (schedule[(t+i+1)%schedule.length] == 1 || schedule[(t+i+1)%schedule.length] == 2) {
 							consec += 24 * 60;
 						} else if (instance.getFromDutyNrToDuty().containsKey(schedule[(t+i+1)%schedule.length])) {
@@ -422,6 +500,7 @@ public class PricingProblem_Phase3
 	public boolean isFeasible14(int[] schedule, int t) {
 		// The constraint has to be tested from the start of a duty, so ATV and rest days can be skipped
 		if (schedule[t] != 1 && schedule[t] != 2) {
+			//Get the start time
 			int start = 0;
 			if (instance.getFromDutyNrToDuty().containsKey(schedule[t])) {
 				start = instance.getFromDutyNrToDuty().get(schedule[t]).getStartTime();
@@ -431,17 +510,22 @@ public class PricingProblem_Phase3
 			
 			int consec14 = 0;
 			
+			//Count onwards 
 			for (int i = 1; i < 14; i++) {
 				if ((schedule[(t+i)%schedule.length] == 1 || schedule[(t+i)%schedule.length] == 2) &&
 						(schedule[(t+i-1)%schedule.length] != 1 && schedule[(t+i-1)%schedule.length] != 2)) {
 					int consec = 24 * 60;
 					
+					//The previous day 
 					if (instance.getFromDutyNrToDuty().containsKey(schedule[(t+i-1)%schedule.length])) {
 						consec += 24 * 60 - instance.getFromDutyNrToDuty().get(schedule[(t+i-1)%schedule.length]).getEndTime();
 					} else {
 						consec += 24 * 60 - instance.getFromRDutyNrToRDuty().get(schedule[(t+i-1)%schedule.length]).getEndTime();
 					}
 					
+					//The next day 
+					
+					//If it's the last day of the period 
 					if (i == 13) {
 						if (schedule[(t+14)%schedule.length] == 1 || schedule[(t+14)%schedule.length] == 2) {
 							consec += start;
@@ -450,7 +534,9 @@ public class PricingProblem_Phase3
 						} else {
 							consec += Math.min(start, instance.getFromRDutyNrToRDuty().get(schedule[(t+14)%schedule.length]).getStartTime());
 						}
-					} else {
+					}
+					//For all other days 
+					else {
 						if (instance.getFromDutyNrToDuty().containsKey(schedule[(t+i+1)%schedule.length])) {
 							consec += instance.getFromDutyNrToDuty().get(schedule[(t+i+1)%schedule.length]).getStartTime();
 						} else if (instance.getFromRDutyNrToRDuty().containsKey(schedule[(t+i+1)%schedule.length])) {
@@ -458,7 +544,7 @@ public class PricingProblem_Phase3
 						} else {
 							int j = 1;
 							while (schedule[(t+i+j)%schedule.length] == 1 || schedule[(t+i+j)%schedule.length] == 2) {
-								if (i+j == 13) {
+								if (i+j == 14) {
 									consec += start;
 									break;
 								}
@@ -468,6 +554,7 @@ public class PricingProblem_Phase3
 						}
 					}
 					
+					//If this period is bigger than the required amount per week, count it 
 					if (consec >= this.consecFreeWeekly) {
 						consec14 += consec;
 					}
@@ -484,6 +571,14 @@ public class PricingProblem_Phase3
 		return false;
 	}
 	
+	/**
+	 * This method determines the shortest path, moving backwards through the graph from one node to the end. Also tracks costs found along the way 
+	 * @param graph				the directed acyclic graph
+	 * @param from				the starting node
+	 * @param to				the final node
+	 * @param costs				whether the source is the costs or the working hours. True = costs, False = working hours. 
+	 * @return					Map of nodes to their shortest paths 
+	 */
 	public Map<Node, Path> shortestPathBackward(DirectedGraph<Node, ArcData> graph, int from, int to, boolean costs) {
 		Map<Node, Path> distances = new HashMap<>();
 		
@@ -515,7 +610,7 @@ public class PricingProblem_Phase3
 	 * @param graph				the directed acyclic graph
 	 * @param from				the starting node
 	 * @param to				the final node
-	 * @param costs				whether the source is the costs or the working hours
+	 * @param costs				whether the source is the costs or the working hours. True = costs, False = working hours. 
 	 * @return					the shortest Path
 	 */
 	public Path shortestPath(DirectedGraph<Node, ArcData> graph, int from, int to, boolean costs) {
@@ -532,6 +627,7 @@ public class PricingProblem_Phase3
 				if (distances.containsKey(outArc.getFrom())) {
 					double newCosts = distances.get(outArc.getFrom()).getCosts();
 					newCosts += outArc.getData().getData(costs);
+					//Updates the costs if they're better, or if they haven't been calculated yet 
 					if (!distances.containsKey(outArc.getTo()) || newCosts < distances.get(outArc.getTo()).getCosts()) {
 						List<Node> newPath = this.copyNodeList(distances.get(outArc.getFrom()).getSchedule());
 						newPath.add(outArc.getTo());
@@ -544,6 +640,16 @@ public class PricingProblem_Phase3
 		return distances.get(graph.getNodes().get(to));
 	}
 	
+	
+	/**
+	 * This method determines the shortest path between two nodes based on either the costs on the arc or the working hours.
+	 * @param graph				the directed acyclic graph
+	 * @param from				the starting node
+	 * @param to				the final node
+	 * @param costs				whether the source is the costs or the working hours. True = costs, False = working hours. 
+	 * @param forbidden			the list of for every day of the week, the duties the shortest path is not allowed to take
+	 * @return					the shortest Path
+	 */
 	public Path shortestPath(DirectedGraph<Node, ArcData> graph, int from, int to, boolean costs, List<Set<Integer>> forbidden) {
 		Map<Node, Path> distances = new HashMap<>();
 		
@@ -555,10 +661,12 @@ public class PricingProblem_Phase3
 		// For all nodes, starting from the from node, update the paths
 		for (int i = from; i < to; i++) {
 			for (DirectedGraphArc<Node, ArcData> outArc : graph.getOutArcs(graph.getNodes().get(i))) {
+				//If this duty hasn't been taken on this day already 
 				if (!forbidden.get(outArc.getTo().getDayNr()%7).contains(outArc.getTo().getDutyNr())) {
 					if (distances.containsKey(outArc.getFrom())) {
 						double newCosts = distances.get(outArc.getFrom()).getCosts();
 						newCosts += outArc.getData().getData(costs);
+						//Updates the costs if they're better, or if they haven't been calculated yet 
 						if (!distances.containsKey(outArc.getTo()) || newCosts < distances.get(outArc.getTo()).getCosts()) {
 							List<Node> newPath = this.copyNodeList(distances.get(outArc.getFrom()).getSchedule());
 							newPath.add(outArc.getTo());
@@ -595,8 +703,10 @@ public class PricingProblem_Phase3
 			for (int t = 0; t < instance.getBasicSchedules().get(c).length; t++) {
 				// Check if its a normal duty, reserve duty, ATV or rest day
 				String type = instance.getBasicSchedules().get(c)[t];
+				
+				//ATV days
 				if (type.equals("ATV")) {
-					Node newNode = new Node(t, 1);
+					Node newNode = new Node(t, 1); //ATV days get duty number 1 
 					newGraph.addNode(newNode);
 					
 					// All nodes on the day before an ATV day should get an arc as always feasible, duty duration equals the average length of a shift
@@ -605,8 +715,10 @@ public class PricingProblem_Phase3
 							newGraph.addArc(prevNode, newNode, new ArcData(0, (int) Math.ceil(c.getAvgHoursPerDay() * 60)));
 						}
 					}
-				} else if (type.equals("Rest")) {
-					Node newNode = new Node(t, 2);
+				}
+				//Rest days
+				else if (type.equals("Rest")) {
+					Node newNode = new Node(t, 2); //Rest days get duty number 2
 					newGraph.addNode(newNode);
 					
 					// All nodes on the day before a rest day should get an arc as always feasible, no working hours
@@ -615,19 +727,29 @@ public class PricingProblem_Phase3
 							newGraph.addArc(prevNode, newNode, new ArcData(0, 0));
 						}
 					}
-				} else if (type.substring(0, 1).equals("R")) {
+				} 
+				//Reserve duties
+				else if (type.substring(0, 1).equals("R")) {
 					Node newNode = new Node(t, this.getReserveDutyType(type.substring(1), t).getNr());
 					newGraph.addNode(newNode);
 					
 					for (Node prevNode : newGraph.getNodes()) {
+						//If we come from the source
 						if (prevNode.equals(source) && t == 0) {
 							newGraph.addArc(prevNode, newNode, new ArcData(0, (int) Math.ceil(c.getAvgHoursPerDay() * 60)));
-						} else if (prevNode.getDayNr() == t - 1) {
+						} 
+						//If we don't come from the source
+						else if (prevNode.getDayNr() == t - 1) {
+							//If we come from an ATV day
 							if (prevNode.getDutyNr() == 1) {
 								newGraph.addArc(prevNode, newNode, new ArcData(0, (int) Math.ceil(c.getAvgHoursPerDay() * 60)));
-							} else if (prevNode.getDutyNr() == 2) {
+							} 
+							//Coming from a rest day
+							else if (prevNode.getDutyNr() == 2) {
 								newGraph.addArc(prevNode, newNode, new ArcData(0, (int) Math.ceil(c.getAvgHoursPerDay() * 60)));
-							} else if (instance.getFromRDutyNrToRDuty().containsKey(prevNode.getDutyNr())) {
+							} 
+							//Coming from another reserve duty
+							else if (instance.getFromRDutyNrToRDuty().containsKey(prevNode.getDutyNr())) {
 								// Check the 11 hour constraint
 								if (instance.getFromRDutyNrToRDuty().get(newNode.getDutyNr()).getStartTime() + 
 										(minPerDay - instance.getFromRDutyNrToRDuty().get(prevNode.getDutyNr()).getEndTime()) >= minBreakBetweenShifts) {
@@ -646,6 +768,8 @@ public class PricingProblem_Phase3
 					// This day is a normal duty
 					Set<Duty> toCreate = new HashSet<>();
 					int weekdayNr = t % 7;
+					
+					//Get the list of duties to create
 					if (weekdayNr == 0) {
 						toCreate = instance.getDutiesPerTypeSun().get(type);
 					} else if (weekdayNr == 6) {
@@ -654,23 +778,30 @@ public class PricingProblem_Phase3
 						toCreate = instance.getDutiesPerTypeW().get(type);
 					}
 					
+					//For all of these duties
 					for (Duty duty : toCreate) {
 						Node newNode = new Node(t, duty.getNr());
 						newGraph.addNode(newNode);
 						
 						for (Node prevNode : newGraph.getNodes()) {
+							//From source
 							if (prevNode.equals(source) && t == 0) {
 								newGraph.addArc(prevNode, newNode, new ArcData(0, duty.getPaidMin()));
-							} else if (prevNode.getDayNr() == t - 1) {
+							} 
+							else if (prevNode.getDayNr() == t - 1) {
+								//From ATV or rest day 
 								if (prevNode.getDutyNr() == 1 || prevNode.getDutyNr() == 2) {
 									// Always add from an ATV or rest day
 									newGraph.addArc(prevNode,  newNode, new ArcData(0, duty.getPaidMin()));
+									
+								//From a reserve duty
 								} else if (instance.getFromRDutyNrToRDuty().containsKey(prevNode.getDutyNr())) {
 									// Check the 11 hour constraint
 									if (instance.getFromDutyNrToDuty().get(newNode.getDutyNr()).getStartTime() + 
 											(minPerDay - instance.getFromRDutyNrToRDuty().get(prevNode.getDutyNr()).getEndTime()) >= minBreakBetweenShifts) {
 										newGraph.addArc(prevNode,  newNode, new ArcData(0, duty.getPaidMin()));
 									}
+								//From a normal duty
 								} else {
 									// Check the 11 hour constraint
 									if (instance.getFromDutyNrToDuty().get(newNode.getDutyNr()).getStartTime() + 
@@ -688,6 +819,7 @@ public class PricingProblem_Phase3
 			Node sink = new Node(instance.getBasicSchedules().get(c).length, 0);
 			newGraph.addNode(sink);
 			
+			//Connect all arcs to the sink
 			for (Node prevNode : newGraph.getNodes()) {
 				if (prevNode.getDayNr() == instance.getBasicSchedules().get(c).length - 1) {
 					newGraph.addArc(prevNode, sink, new ArcData(0, 0));
@@ -777,19 +909,20 @@ public class PricingProblem_Phase3
 	 * @param sink					the sink
 	 */
 	public void removeNodes(DirectedGraph<Node, ArcData> graph, ContractGroup c, Node source, Node sink) {
-		boolean check = true;
-		while (check) {
+		boolean check = true; //Whether anything has to be removed 
+		while (check) {//Loop until we have no more removals 
 			check = false;
 			Set<Node> toRemove = new HashSet<>();
 			for (Node curNode : graph.getNodes()) {
-				if (graph.getOutDegree(curNode) == 0 && !curNode.equals(sink)) {
+				if (graph.getOutDegree(curNode) == 0 && !curNode.equals(sink)) {//If there are no outgoing arcs
 					toRemove.add(curNode);
 					check = true;
-				} else if (graph.getInDegree(curNode) == 0 && !curNode.equals(source)) {
+				} else if (graph.getInDegree(curNode) == 0 && !curNode.equals(source)) {//If there are no incoming arcs 
 					toRemove.add(curNode);
 					check = true;
 				}
 			}
+			//Remove everything
 			for (Node curNode : toRemove) {
 				graph.removeNode(curNode);
 			}
@@ -829,13 +962,13 @@ public class PricingProblem_Phase3
 		// For each ingoing arc, put the dual costs on that ingoing duty
 		for (ContractGroup c : instance.getContractGroups()) {
 			for (DirectedGraphArc<Node, ArcData> curArc : graphs.get(c).getArcs()) {
-				if (curArc.getFrom().getDayNr() == -1) {
+				if (curArc.getFrom().getDayNr() == -1) { //If this node is the source
 					if (instance.getFromDutyNrToDuty().containsKey(curArc.getTo().getDutyNr())) {
 						curArc.getData().setDualCosts(-dualsContractGroup[c.getNr() - 1] - dualsDuties.get(0).get(curArc.getTo().getDutyNr()));
 					} else {
 						curArc.getData().setDualCosts(-dualsContractGroup[c.getNr() - 1]);
 					}
-					
+				//For all nodes that aren't the source or the sink, and if it's a normal duty 
 				} else if (curArc.getTo().getDayNr() != instance.getBasicSchedules().get(c).length && instance.getFromDutyNrToDuty().containsKey(curArc.getTo().getDutyNr())) {
 					curArc.getData().setDualCosts(-dualsDuties.get(curArc.getTo().getDayNr()%7).get(curArc.getTo().getDutyNr()));
 				}

--- a/src/PricingProblem_Phase3.java
+++ b/src/PricingProblem_Phase3.java
@@ -169,7 +169,7 @@ public class PricingProblem_Phase3
 			if (totOvertime != Integer.MAX_VALUE) {
 				this.finalSchedules.add(new Schedule(c, totOvertime, curPulse.getSchedule()));
 			}
-		} else if (finalSchedules.size() != maxSchedules && (System.nanoTime() - startTime)/1000000000.0 < 10) {
+		} else if (finalSchedules.size() != maxSchedules && (System.nanoTime() - startTime)/1000000000.0 < 15) {
 			// Check whether the new schedule would be feasible in terms of 7x24 and 14x24 hours
 			int[] schedule = this.copyIntArray(curPulse.getSchedule());
 			schedule[curArc.getTo().getDayNr()] = curArc.getTo().getDutyNr();

--- a/src/RMP_Phase3.java
+++ b/src/RMP_Phase3.java
@@ -161,7 +161,7 @@ public class RMP_Phase3 {
 		for (int c = 0; c < this.dummies2.length; c++) {
 			IloNumExpr lhs = cplex.constant(0); 
 			lhs = cplex.sum(lhs, this.dummies2[c]);
-			this.constraints2[c] = cplex.addEq(lhs, 1, "Contractgroup_" + c);	
+			this.constraints2[c] = cplex.addGe(lhs, 1, "Contractgroup_" + c);	
 		}
 	}
 	//Method that returns the dual values of the first type of constraints;

--- a/src/Tools/Instance.java
+++ b/src/Tools/Instance.java
@@ -228,7 +228,7 @@ public class Instance
 		
 		for (ContractGroup c : this.contractGroups) {
 			
-			c.setTc((int) Math.ceil(nDrivers * c.getRelativeGroupSize()) * 7);
+			c.setTc((int) Math.floor(nDrivers * c.getRelativeGroupSize()) * 7);
 			c.setATVc((int) Math.floor(c.getATVPerYear() / 365.0 * c.getTc()));
 		}
 	}


### PR DESCRIPTION
New constraints added to the MIP:
- Penalty on lonely duties
- Penalty on ATV on weekends
- Penalty on more than two split duties on average
- Penalty on more than 3 rest days in a week (to better spread rest) 
Penalty methods can be turned on and off at will for sake of computational time.

Other changes:
- Fixed some of the constraints in the MIP 
- Column Generation RMP operates on Ge constraints
- Instance now rounds down the number of drivers to get more variability in the driver numbers 